### PR TITLE
Added WiFi MAC address getter for Zephyr platform

### DIFF
--- a/src/platform/Zephyr/BUILD.gn
+++ b/src/platform/Zephyr/BUILD.gn
@@ -66,6 +66,13 @@ static_library("Zephyr") {
     }
   }
 
+if (chip_enable_wifi) {
+  sources += [
+    "WiFiManager.cpp",
+    "WiFiManager.h",
+    ]
+}
+
   if (chip_enable_nfc) {
     sources += [
       "NFCManagerImpl.cpp",

--- a/src/platform/Zephyr/BUILD.gn
+++ b/src/platform/Zephyr/BUILD.gn
@@ -66,13 +66,6 @@ static_library("Zephyr") {
     }
   }
 
-if (chip_enable_wifi) {
-  sources += [
-    "WiFiManager.cpp",
-    "WiFiManager.h",
-    ]
-}
-
   if (chip_enable_nfc) {
     sources += [
       "NFCManagerImpl.cpp",

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -27,6 +27,7 @@
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
 #include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <platform/Zephyr/WiFiManager.h>
 #include <platform/Zephyr/ZephyrConfig.h>
 
 #include <lib/support/CodeUtils.h>
@@ -178,6 +179,15 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
     PlatformMgr().Shutdown();
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    return WiFiManager::Instance().GetMACAddress(buf);
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -94,10 +94,5 @@ inline CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::P
     return Internal::ZephyrConfig::WriteConfigValueCounter(key, value);
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * /* buf */)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/WiFiManager.cpp
+++ b/src/platform/Zephyr/WiFiManager.cpp
@@ -144,5 +144,16 @@ std::string WiFiManager::ExtractNetworkStatusString(const std::string & aFullStr
     return wpaStateValueSubStr.substr(0, pos);
 }
 
+CHIP_ERROR WiFiManager::GetMACAddress(uint8_t * buf)
+{
+    // CONFIG_NET_DEFAULT_IF_FIRST is set by default
+    const net_if * const iface = net_if_get_default();
+    VerifyOrReturnError(iface != nullptr && iface->if_dev != nullptr, CHIP_ERROR_INTERNAL);
+
+    const auto linkAddrStruct = iface->if_dev->link_addr;
+    memcpy(buf, linkAddrStruct.addr, linkAddrStruct.len);
+    return CHIP_NO_ERROR;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/WiFiManager.h
+++ b/src/platform/Zephyr/WiFiManager.h
@@ -55,6 +55,7 @@ public:
     CHIP_ERROR AddNetwork(const ByteSpan & ssid, const ByteSpan & credentials);
     CHIP_ERROR Connect();
     StationStatus NetworkStatus();
+    CHIP_ERROR GetMACAddress(uint8_t * buf);
 
 private:
     CHIP_ERROR AddPsk(const ByteSpan & credentials);


### PR DESCRIPTION
This is needed for commissioning and multicasting.
