### PR TITLE
Support IPv6 multicast + adapt UDP endpoint implementation

### DIFF
--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -250,4 +250,26 @@
 #ifndef INET_CONFIG_IP_MULTICAST_HOP_LIMIT
 #define INET_CONFIG_IP_MULTICAST_HOP_LIMIT                 (64)
 #endif // INET_CONFIG_IP_MULTICAST_HOP_LIMIT
+
+/**
+ *  @def INET_CONFIG_UDP_SOCKET_PKTINFO
+ *
+ *  @brief
+ *    Use IP_PKTINFO and IPV6_PKTINFO control messages to specify the network
+ *    interface and the source address of a sent UDP packet.
+ *
+ *  @details
+ *    When this flag is set, the socket-based implementation of UDP endpoints
+ *    requires that IP_PKTINFO and IPV6_PKTINFO be supported. Otherwise, it is
+ *    left to the operating system to select the network interface and the
+ *    source address.
+ */
+#ifndef INET_CONFIG_UDP_SOCKET_PKTINFO
+#ifndef __ZEPHYR__
+#define INET_CONFIG_UDP_SOCKET_PKTINFO 1
+#else
+#define INET_CONFIG_UDP_SOCKET_PKTINFO 0
+#endif
+#endif // INET_CONFIG_UDP_SOCKET_PKTINFO
+
 // clang-format on

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -61,7 +61,7 @@
 #define INET_IPV6_ADD_MEMBERSHIP IPV6_ADD_MEMBERSHIP
 #elif defined(IPV6_JOIN_GROUP)
 #define INET_IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
-#elif !__ZEPHYR__
+#elif !CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 #error                                                                                                                             \
     "Neither IPV6_ADD_MEMBERSHIP nor IPV6_JOIN_GROUP are defined which are required for generalized IPv6 multicast group support."
 #endif // IPV6_ADD_MEMBERSHIP
@@ -70,7 +70,7 @@
 #define INET_IPV6_DROP_MEMBERSHIP IPV6_DROP_MEMBERSHIP
 #elif defined(IPV6_LEAVE_GROUP)
 #define INET_IPV6_DROP_MEMBERSHIP IPV6_LEAVE_GROUP
-#elif !__ZEPHYR__
+#elif !CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 #error                                                                                                                             \
     "Neither IPV6_DROP_MEMBERSHIP nor IPV6_LEAVE_GROUP are defined which are required for generalized IPv6 multicast group support."
 #endif // IPV6_DROP_MEMBERSHIP
@@ -345,6 +345,7 @@ CHIP_ERROR UDPEndPointImplSockets::SendMsgImpl(const IPPacketInfo * aPktInfo, Sy
         intf = mBoundIntfId;
     }
 
+#if INET_CONFIG_UDP_SOCKET_PKTINFO
     // If the packet should be sent over a specific interface, or with a specific source
     // address, construct an IP_PKTINFO/IPV6_PKTINFO "control message" to that effect
     // add add it to the message header.  If the local OS doesn't support IP_PKTINFO/IPV6_PKTINFO
@@ -409,6 +410,7 @@ CHIP_ERROR UDPEndPointImplSockets::SendMsgImpl(const IPPacketInfo * aPktInfo, Sy
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
     }
+#endif // INET_CONFIG_UDP_SOCKET_PKTINFO
 
     // Send IP packet.
     const ssize_t lenSent = sendmsg(mSocket, &msgHeader, 0);

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -583,7 +583,8 @@ void UDPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)
     System::PacketBufferHandle lBuffer;
 
     lPacketInfo.Clear();
-    lPacketInfo.DestPort = mBoundPort;
+    lPacketInfo.DestPort  = mBoundPort;
+    lPacketInfo.Interface = mBoundIntfId;
 
     lBuffer = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSizeWithoutReserve, 0);
 

--- a/src/platform/Zephyr/WiFiManager.cpp
+++ b/src/platform/Zephyr/WiFiManager.cpp
@@ -24,10 +24,12 @@
 
 #include <cstdlib>
 
+#include <inet/InetInterface.h>
+#include <inet/UDPEndPointImplSockets.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #include "common.h"
-#include <lib/support/logging/CHIPLogging.h>
 #include <net/net_event.h>
 #include <net/net_if.h>
 #include <net/wifi_mgmt.h>
@@ -35,6 +37,7 @@
 
 extern "C" {
 #include <utils/common.h>
+
 #include <config.h>
 #include <ctrl_iface.h>
 #include <wpa_supplicant_i.h>
@@ -45,6 +48,25 @@ extern struct wpa_supplicant * wpa_s_0;
 namespace chip {
 namespace DeviceLayer {
 
+namespace {
+
+in6_addr ToZephyrAddr(const Inet::IPAddress & address)
+{
+    in6_addr zephyrAddr;
+
+    static_assert(sizeof(zephyrAddr.s6_addr) == sizeof(address.Addr), "Unexpected address size");
+    memcpy(zephyrAddr.s6_addr, address.Addr, sizeof(address.Addr));
+
+    return zephyrAddr;
+}
+
+net_if * GetInterface(Inet::InterfaceId interfaceId = Inet::InterfaceId::Null())
+{
+    return interfaceId.IsPresent() ? net_if_get_by_index(interfaceId.GetPlatformInterface()) : net_if_get_default();
+}
+
+} // namespace
+
 CHIP_ERROR WiFiManager::Init()
 {
     // wpa_supplicant instance should be initialized in dedicated supplicant thread
@@ -53,11 +75,38 @@ CHIP_ERROR WiFiManager::Init()
         ChipLogError(DeviceLayer, "wpa_supplicant is not initialized!");
         return CHIP_ERROR_INTERNAL;
     }
-    else
-    {
-        ChipLogDetail(DeviceLayer, "wpa_supplicant has been initialized");
+
+    // TODO: consider moving these to ConnectivityManagerImpl to be prepared for handling multiple interfaces on a single device.
+    Inet::UDPEndPointImplSockets::SetJoinMulticastGroupHandler([](Inet::InterfaceId interfaceId, const Inet::IPAddress & address) {
+        const in6_addr addr = ToZephyrAddr(address);
+        net_if * iface      = GetInterface(interfaceId);
+        VerifyOrReturnError(iface != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
+
+        net_if_mcast_addr * maddr = net_if_ipv6_maddr_add(iface, &addr);
+
+        if (maddr && !net_if_ipv6_maddr_is_joined(maddr) && !net_ipv6_is_addr_mcast_link_all_nodes(&addr))
+        {
+            net_if_ipv6_maddr_join(maddr);
+        }
+
         return CHIP_NO_ERROR;
-    }
+    });
+
+    Inet::UDPEndPointImplSockets::SetLeaveMulticastGroupHandler([](Inet::InterfaceId interfaceId, const Inet::IPAddress & address) {
+        const in6_addr addr = ToZephyrAddr(address);
+        net_if * iface      = GetInterface(interfaceId);
+        VerifyOrReturnError(iface != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
+
+        if (!net_ipv6_is_addr_mcast_link_all_nodes(&addr) && !net_if_ipv6_maddr_rm(iface, &addr))
+        {
+            return CHIP_ERROR_INVALID_ADDRESS;
+        }
+
+        return CHIP_NO_ERROR;
+    });
+
+    ChipLogDetail(DeviceLayer, "wpa_supplicant has been initialized");
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WiFiManager::AddNetwork(const ByteSpan & ssid, const ByteSpan & credentials)
@@ -146,8 +195,7 @@ std::string WiFiManager::ExtractNetworkStatusString(const std::string & aFullStr
 
 CHIP_ERROR WiFiManager::GetMACAddress(uint8_t * buf)
 {
-    // CONFIG_NET_DEFAULT_IF_FIRST is set by default
-    const net_if * const iface = net_if_get_default();
+    const net_if * const iface = GetInterface();
     VerifyOrReturnError(iface != nullptr && iface->if_dev != nullptr, CHIP_ERROR_INTERNAL);
 
     const auto linkAddrStruct = iface->if_dev->link_addr;

--- a/src/platform/Zephyr/WiFiManager.h
+++ b/src/platform/Zephyr/WiFiManager.h
@@ -26,6 +26,7 @@
 #include <lib/support/Span.h>
 #include <string>
 
+struct net_if;
 struct wpa_ssid;
 using WpaNetwork = struct wpa_ssid;
 


### PR DESCRIPTION
* Implement functions for joining and leaving multicast groups
* Workaround lack of support for `IP_PKTINFO` and `IPV6_PKTINFO` control messages in Zephyr sockets.