### PR TITLE
Add Wi-Fi network scan functionality

### DIFF
--- a/src/platform/Zephyr/WiFiManager.cpp
+++ b/src/platform/Zephyr/WiFiManager.cpp
@@ -32,6 +32,7 @@
 extern "C" {
 #include <wpa_supplicant/config.h>
 #include <wpa_supplicant/scan.h>
+#include <zephyr_fmac_main.h>
 }
 
 extern struct wpa_supplicant * wpa_s_0;
@@ -49,6 +50,29 @@ in6_addr ToZephyrAddr(const Inet::IPAddress & address)
     memcpy(zephyrAddr.s6_addr, address.Addr, sizeof(address.Addr));
 
     return zephyrAddr;
+}
+
+NetworkCommissioning::WiFiScanResponse ToScanResponse(wifi_scan_result * result)
+{
+    NetworkCommissioning::WiFiScanResponse response = {};
+
+    if (result != nullptr)
+    {
+        static_assert(sizeof(response.ssid) == sizeof(result->ssid), "SSID length mismatch");
+        static_assert(sizeof(response.bssid) == sizeof(result->mac), "BSSID length mismatch");
+
+        // TODO: Distinguish WPA versions
+        response.security.Set(result->security == WIFI_SECURITY_TYPE_PSK ? NetworkCommissioning::WiFiSecurity::kWpaPersonal
+                                                                         : NetworkCommissioning::WiFiSecurity::kUnencrypted);
+        response.channel = result->channel;
+        response.rssi    = result->rssi;
+        response.ssidLen = result->ssid_length;
+        memcpy(response.ssid, result->ssid, result->ssid_length);
+        // TODO: MAC/BSSID is not filled by the Wi-Fi driver
+        memcpy(response.bssid, result->mac, result->mac_length);
+    }
+
+    return response;
 }
 
 net_if * GetInterface(Inet::InterfaceId ifaceId = Inet::InterfaceId::Null())
@@ -150,6 +174,32 @@ CHIP_ERROR WiFiManager::AddNetwork(const ByteSpan & ssid, const ByteSpan & crede
     }
 
     return CHIP_ERROR_INTERNAL;
+}
+
+CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanCallback callback)
+{
+    net_if * const iface = GetInterface();
+    VerifyOrReturnError(iface != nullptr, CHIP_ERROR_INTERNAL);
+
+    const device * dev = net_if_get_device(iface);
+    VerifyOrReturnError(dev != nullptr, CHIP_ERROR_INTERNAL);
+
+    const wifi_nrf_dev_ops * ops = static_cast<const wifi_nrf_dev_ops *>(dev->api);
+    VerifyOrReturnError(ops != nullptr, CHIP_ERROR_INTERNAL);
+
+    mScanCallback = callback;
+
+    // TODO: Use saner API once such exists.
+    // TODO: Take 'ssid' into account.
+    VerifyOrReturnError(ops->off_api.disp_scan(dev,
+                                               [](net_if *, int status, wifi_scan_result * result) {
+                                                   VerifyOrReturn(Instance().mScanCallback != nullptr);
+                                                   NetworkCommissioning::WiFiScanResponse response = ToScanResponse(result);
+                                                   Instance().mScanCallback(status, result != nullptr ? &response : nullptr);
+                                               }) == 0,
+                        CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WiFiManager::Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling)

--- a/src/platform/Zephyr/WiFiManager.h
+++ b/src/platform/Zephyr/WiFiManager.h
@@ -24,6 +24,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/Span.h>
+#include <platform/NetworkCommissioning.h>
 #include <system/SystemLayer.h>
 
 #include <net/net_if.h>
@@ -84,6 +85,8 @@ public:
         return sInstance;
     }
 
+    using ScanCallback = void (*)(int /* status */, NetworkCommissioning::WiFiScanResponse *);
+
     struct ConnectionHandling
     {
         ConnectionCallback mOnConnectionSuccess{};
@@ -92,6 +95,7 @@ public:
     };
 
     CHIP_ERROR Init();
+    CHIP_ERROR Scan(const ByteSpan & ssid, ScanCallback callback);
     CHIP_ERROR Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling);
     CHIP_ERROR GetMACAddress(uint8_t * buf);
     StationStatus GetStationStatus();
@@ -112,6 +116,7 @@ private:
     ConnectionCallback mConnectionSuccessClbk;
     ConnectionCallback mConnectionFailedClbk;
     System::Clock::Timeout mConnectionTimeoutMs;
+    ScanCallback mScanCallback{ nullptr };
 };
 
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -21,19 +21,23 @@
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
-namespace {
+
 constexpr uint8_t kMaxWiFiNetworks                  = 1;
 constexpr uint8_t kWiFiScanNetworksTimeOutSeconds   = 10;
 constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 120;
-} // namespace
 
-class NrfScanResponseIterator : public Iterator<WiFiScanResponse>
+class NrfWiFiScanResponseIterator : public Iterator<WiFiScanResponse>
 {
 public:
-    virtual ~NrfScanResponseIterator() = default;
-    size_t Count() override { return 0; }
-    bool Next(WiFiScanResponse & item) override { return true; }
-    void Release() override {}
+    size_t Count() override { return mResultCount; }
+    bool Next(WiFiScanResponse & item) override;
+    void Release() override;
+    void Add(const WiFiScanResponse & result);
+
+private:
+    size_t mResultId            = 0;
+    size_t mResultCount         = 0;
+    WiFiScanResponse * mResults = nullptr;
 };
 
 class NrfWiFiDriver final : public WiFiDriver
@@ -101,6 +105,7 @@ public:
     void OnConnectWiFiNetwork();
     void OnConnectWiFiNetworkFailed();
     void OnNetworkStatusChanged(Status status);
+    void OnScanWiFiNetworkDone(int status, WiFiScanResponse * result);
 
 private:
     void LoadFromStorage();
@@ -108,6 +113,8 @@ private:
     ConnectCallback * mpConnectCallback{ nullptr };
     NetworkStatusChangeCallback * mpNetworkStatusChangeCallback{ nullptr };
     WiFiNetwork mStagingNetwork;
+    NrfWiFiScanResponseIterator mScanResponseIterator;
+    ScanCallback * mScanCallback{ nullptr };
 };
 
 } // namespace NetworkCommissioning


### PR DESCRIPTION
Make sure that the following procedure successfully finds
Wi-Fi networks in the neighborhood:

chip-tool interactive start
> pairing code-paseonly 1 <qrcode>
> networkcommissioning scan-networks 1 0

Note that currently the driver does not differentiate WPA
versions nor it fills BSSID/MAC field.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
