### PR TITLE
[nrfconnect] matter-wifi: added support for WiFi diagnostic cluster

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -37,6 +37,8 @@ config CHIP_WIFI
 	imply USE_DT_CODE_PARTITION # might be removed when the OTA is enabled
 	imply NET_IPV6_ND # enable Neighbor Discovery to handle Router Advertisements
 	imply NET_IPV6_NBR_CACHE
+	imply NET_STATISTICS_IPV6
+	imply NET_STATISTICS_USER_API
 
 config CHIP_QSPI_NOR
 	bool "Enable QSPI NOR feature set"

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -36,7 +36,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
-#ifdef CONFIG_CHIP_WIFI
+#ifdef CONFIG_WIFI_NRF700X
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
 #endif
@@ -128,7 +128,7 @@ constexpr uint32_t kOff_ms{ 950 };
 } // namespace StatusLed
 } // namespace LedConsts
 
-#ifdef CONFIG_CHIP_WIFI
+#ifdef CONFIG_WIFI_NRF700X
 app::Clusters::NetworkCommissioning::Instance sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
 #endif
 
@@ -169,7 +169,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif defined(CONFIG_CHIP_WIFI)
+#elif defined(CONFIG_WIFI_NRF700X)
     sWiFiCommissioningInstance.Init();
 #endif
 

--- a/examples/chef/nrfconnect/main.cpp
+++ b/examples/chef/nrfconnect/main.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR main()
         ChipLogError(AppServer, "ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif !defined(CONFIG_CHIP_WIFI)
+#elif !defined(CONFIG_WIFI_NRF700X)
     return CHIP_ERROR_INTERNAL;
 #endif
 

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -134,7 +134,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed: %s", ErrorStr(err));
         return err;
     }
-#elif !defined(CONFIG_CHIP_WIFI)
+#elif !defined(CONFIG_WIFI_NRF700X)
     return CHIP_ERROR_INTERNAL;
 #endif
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif !defined(CONFIG_CHIP_WIFI)
+#elif !defined(CONFIG_WIFI_NRF700X)
     return CHIP_ERROR_INTERNAL;
 #endif
 

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -40,7 +40,7 @@
 #include <lib/support/ErrorStr.h>
 #include <system/SystemClock.h>
 
-#ifdef CONFIG_CHIP_WIFI
+#ifdef CONFIG_WIFI_NRF700X
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
 #endif
@@ -90,7 +90,7 @@ chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 } // namespace
 
-#ifdef CONFIG_CHIP_WIFI
+#ifdef CONFIG_WIFI_NRF700X
 app::Clusters::NetworkCommissioning::Instance sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
 #endif
 
@@ -133,7 +133,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif defined(CONFIG_CHIP_WIFI)
+#elif defined(CONFIG_WIFI_NRF700X)
     sWiFiCommissioningInstance.Init();
 #else
     return CHIP_ERROR_INTERNAL;

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -119,7 +119,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif !defined(CONFIG_CHIP_WIFI)
+#elif !defined(CONFIG_WIFI_NRF700X)
     return CHIP_ERROR_INTERNAL;
 #endif
 

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -118,7 +118,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif !defined(CONFIG_CHIP_WIFI)
+#elif !defined(CONFIG_WIFI_NRF700X)
     return CHIP_ERROR_INTERNAL;
 #endif
 

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -126,7 +126,7 @@ CHIP_ERROR AppTask::Init()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         return err;
     }
-#elif !defined(CONFIG_CHIP_WIFI)
+#elif !defined(CONFIG_WIFI_NRF700X)
     return CHIP_ERROR_INTERNAL;
 #endif
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -27,6 +27,7 @@
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/Zephyr/DiagnosticDataProviderImpl.h>
 #include <platform/Zephyr/SysHeapMalloc.h>
+#include <platform/Zephyr/WiFiManager.h>
 
 #include <drivers/hwinfo.h>
 #include <sys/util.h>
@@ -325,6 +326,97 @@ DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
 {
     return DiagnosticDataProviderImpl::GetDefaultInstance();
 }
+
+#ifdef CONFIG_CHIP_WIFI
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    value          = info.mBssId;
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(uint8_t & securityType)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    securityType   = info.mSecurityType;
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(uint8_t & wiFiVersion)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    wiFiVersion    = info.mWiFiVersion;
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiChannelNumber(uint16_t & channelNumber)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    channelNumber  = info.mChannel;
+    (void) err;
+    // above will return 0 until the wpa_supplicant driver API implementation is refined
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiRssi(int8_t & rssi)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    rssi           = info.mRssi;
+    (void) err;
+    // above will return -128 until the wpa_supplicant driver API implementation is refined
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+// below will be implemented when the WiFi driver exposes Zephyr NET_STATISTICS API
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -27,7 +27,10 @@
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/Zephyr/DiagnosticDataProviderImpl.h>
 #include <platform/Zephyr/SysHeapMalloc.h>
-#include <platform/Zephyr/WiFiManager.h>
+
+#ifdef CONFIG_WIFI_NRF700X
+#include <platform/nrfconnect/wifi/WiFiManager.h>
+#endif
 
 #include <drivers/hwinfo.h>
 #include <sys/util.h>
@@ -110,7 +113,7 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
     return sInstance;
 }
 
-inline DiagnosticDataProviderImpl::DiagnosticDataProviderImpl() : mBootReason(DetermineBootReason())
+DiagnosticDataProviderImpl::DiagnosticDataProviderImpl() : mBootReason(DetermineBootReason())
 {
     ChipLogDetail(DeviceLayer, "Boot reason: %u", static_cast<uint16_t>(mBootReason));
 }
@@ -321,102 +324,6 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
         delete del;
     }
 }
-
-DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
-{
-    return DiagnosticDataProviderImpl::GetDefaultInstance();
-}
-
-#ifdef CONFIG_CHIP_WIFI
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(ByteSpan & value)
-{
-    WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    value          = info.mBssId;
-    return err;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(uint8_t & securityType)
-{
-    WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    securityType   = info.mSecurityType;
-    return err;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(uint8_t & wiFiVersion)
-{
-    WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    wiFiVersion    = info.mWiFiVersion;
-    return err;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiChannelNumber(uint16_t & channelNumber)
-{
-    WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    channelNumber  = info.mChannel;
-    (void) err;
-    // above will return 0 until the wpa_supplicant driver API implementation is refined
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiRssi(int8_t & rssi)
-{
-    WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    rssi           = info.mRssi;
-    (void) err;
-    // above will return -128 until the wpa_supplicant driver API implementation is refined
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-// below will be implemented when the WiFi driver exposes Zephyr NET_STATISTICS API
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -28,10 +28,6 @@
 #include <platform/Zephyr/DiagnosticDataProviderImpl.h>
 #include <platform/Zephyr/SysHeapMalloc.h>
 
-#ifdef CONFIG_WIFI_NRF700X
-#include <platform/nrfconnect/wifi/WiFiManager.h>
-#endif
-
 #include <drivers/hwinfo.h>
 #include <sys/util.h>
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -52,6 +52,23 @@ public:
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
+#ifdef CONFIG_CHIP_WIFI
+    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
+    CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType) override;
+    CHIP_ERROR GetWiFiVersion(uint8_t & wiFiVersion) override;
+    CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;
+    CHIP_ERROR GetWiFiRssi(int8_t & rssi) override;
+    CHIP_ERROR GetWiFiBeaconLostCount(uint32_t & beaconLostCount) override;
+    CHIP_ERROR GetWiFiBeaconRxCount(uint32_t & beaconRxCount) override;
+    CHIP_ERROR GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount) override;
+    CHIP_ERROR GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount) override;
+    CHIP_ERROR GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount) override;
+    CHIP_ERROR GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount) override;
+    CHIP_ERROR GetWiFiCurrentMaxRate(uint64_t & currentMaxRate) override;
+    CHIP_ERROR GetWiFiOverrunCount(uint64_t & overrunCount) override;
+    CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
+#endif
+
 private:
     DiagnosticDataProviderImpl();
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -52,26 +52,10 @@ public:
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
-#ifdef CONFIG_CHIP_WIFI
-    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
-    CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType) override;
-    CHIP_ERROR GetWiFiVersion(uint8_t & wiFiVersion) override;
-    CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;
-    CHIP_ERROR GetWiFiRssi(int8_t & rssi) override;
-    CHIP_ERROR GetWiFiBeaconLostCount(uint32_t & beaconLostCount) override;
-    CHIP_ERROR GetWiFiBeaconRxCount(uint32_t & beaconRxCount) override;
-    CHIP_ERROR GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount) override;
-    CHIP_ERROR GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount) override;
-    CHIP_ERROR GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount) override;
-    CHIP_ERROR GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount) override;
-    CHIP_ERROR GetWiFiCurrentMaxRate(uint64_t & currentMaxRate) override;
-    CHIP_ERROR GetWiFiOverrunCount(uint64_t & overrunCount) override;
-    CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
-#endif
-
-private:
+protected:
     DiagnosticDataProviderImpl();
 
+private:
     const BootReasonType mBootReason;
 };
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImplGetter.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImplGetter.cpp
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DiagnosticDataProviderImpl.h"
+
+namespace chip {
+namespace DeviceLayer {
+
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -45,6 +45,8 @@ static_library("nrfconnect") {
     "ConnectivityManagerImpl.h",
     "DeviceNetworkProvisioningDelegateImpl.cpp",
     "DeviceNetworkProvisioningDelegateImpl.h",
+    "DiagnosticDataProviderImplNrf.cpp",
+    "DiagnosticDataProviderImplNrf.h",
     "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.h",
     "PlatformManagerImpl.h",

--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
@@ -1,0 +1,136 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the DiagnosticDataProvider object
+ *          for nrfconnect platform.
+ */
+
+#include "DiagnosticDataProviderImplNrf.h"
+
+#ifdef CONFIG_WIFI_NRF700X
+#include <platform/nrfconnect/wifi/WiFiManager.h>
+#endif
+
+namespace chip {
+namespace DeviceLayer {
+
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImplNrf::GetDefaultInstance();
+}
+
+DiagnosticDataProviderImplNrf & DiagnosticDataProviderImplNrf::GetDefaultInstance()
+{
+    static DiagnosticDataProviderImplNrf sInstance;
+    return sInstance;
+}
+
+#ifdef CONFIG_WIFI_NRF700X
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBssId(ByteSpan & value)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    value          = info.mBssId;
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiSecurityType(uint8_t & securityType)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    securityType   = info.mSecurityType;
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiVersion(uint8_t & wiFiVersion)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    wiFiVersion    = info.mWiFiVersion;
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiChannelNumber(uint16_t & channelNumber)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    channelNumber  = info.mChannel;
+    (void) err;
+    // above will return 0 until the wpa_supplicant driver API implementation is refined
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiRssi(int8_t & rssi)
+{
+    WiFiManager::WiFiInfo info;
+    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
+    rssi           = info.mRssi;
+    (void) err;
+    // above will return -128 until the wpa_supplicant driver API implementation is refined
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+// below will be implemented when the WiFi driver exposes Zephyr NET_STATISTICS API
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiOverrunCount(uint64_t & overrunCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR DiagnosticDataProviderImplNrf::ResetWiFiNetworkDiagnosticsCounts()
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+#endif
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.h
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.h
@@ -1,0 +1,60 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the DiagnosticDataProvider object
+ *           for nrfconnect platform.
+ */
+
+#pragma once
+
+#include <platform/Zephyr/DiagnosticDataProviderImpl.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class DiagnosticDataProviderImplNrf : public DiagnosticDataProviderImpl
+{
+public:
+#ifdef CONFIG_WIFI_NRF700X
+    CHIP_ERROR GetWiFiBssId(ByteSpan & value) override;
+    CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType) override;
+    CHIP_ERROR GetWiFiVersion(uint8_t & wiFiVersion) override;
+    CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber) override;
+    CHIP_ERROR GetWiFiRssi(int8_t & rssi) override;
+    CHIP_ERROR GetWiFiBeaconLostCount(uint32_t & beaconLostCount) override;
+    CHIP_ERROR GetWiFiBeaconRxCount(uint32_t & beaconRxCount) override;
+    CHIP_ERROR GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount) override;
+    CHIP_ERROR GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount) override;
+    CHIP_ERROR GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount) override;
+    CHIP_ERROR GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount) override;
+    CHIP_ERROR GetWiFiCurrentMaxRate(uint64_t & currentMaxRate) override;
+    CHIP_ERROR GetWiFiOverrunCount(uint64_t & overrunCount) override;
+    CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
+#endif
+
+    static DiagnosticDataProviderImplNrf & GetDefaultInstance();
+
+private:
+    DiagnosticDataProviderImplNrf() = default;
+};
+
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -365,26 +365,27 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 
 uint8_t WiFiManager::GetSecurityType() const
 {
-    VerifyOrReturnValue(nullptr != mpWpaNetwork, 0);
+    VerifyOrReturnValue(nullptr != mpWpaNetwork, EMBER_ZCL_SECURITY_TYPE_UNSPECIFIED);
 
     if ((mpWpaNetwork->key_mgmt & WPA_KEY_MGMT_NONE) || !wpa_key_mgmt_wpa_any(mpWpaNetwork->key_mgmt))
     {
-        return 1; // NONE
+        return EMBER_ZCL_SECURITY_TYPE_NONE;
     }
     else if (wpa_key_mgmt_wpa_psk_no_sae(mpWpaNetwork->key_mgmt))
     {
-        return (mpWpaNetwork->pairwise_cipher & (WPA_CIPHER_TKIP | WPA_CIPHER_CCMP)) ? 4 : 3; // 4-WPA2, 3-WPA
+        return (mpWpaNetwork->pairwise_cipher & (WPA_CIPHER_TKIP | WPA_CIPHER_CCMP)) ? EMBER_ZCL_SECURITY_TYPE_WPA2
+                                                                                     : EMBER_ZCL_SECURITY_TYPE_WPA3;
     }
     else if (wpa_key_mgmt_sae(mpWpaNetwork->key_mgmt))
     {
-        return 5; // WPA3
+        return EMBER_ZCL_SECURITY_TYPE_WPA3;
     }
     else
     {
-        return 2; // WEP
+        return EMBER_ZCL_SECURITY_TYPE_WEP;
     }
 
-    return 0; // Unspecified
+    return EMBER_ZCL_SECURITY_TYPE_UNSPECIFIED;
 }
 
 uint8_t WiFiManager::FrequencyToChannel(uint16_t freq)
@@ -414,7 +415,7 @@ CHIP_ERROR WiFiManager::GetNetworkStatistics(NetworkStatistics & stats) const
     // TODO: below will not work (result will be all zeros) until
     // the get_stats handler is implemented in WiFi driver
     net_stats_eth data{};
-    net_mgmt(NET_REQUEST_STATS_GET_ETHERNET, GetInterface(), &data, sizeof(data));
+    net_mgmt(NET_REQUEST_STATS_GET_ETHERNET, InetUtils::GetInterface(), &data, sizeof(data));
 
     stats.mPacketMulticastRxCount = data.multicast.rx;
     stats.mPacketMulticastTxCount = data.multicast.tx;

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -28,10 +28,13 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Zephyr/InetUtils.h>
 
+#include <net/net_stats.h>
 #include <zephyr.h>
 
 extern "C" {
+#include <common/defs.h>
 #include <wpa_supplicant/config.h>
+#include <wpa_supplicant/driver_i.h>
 #include <wpa_supplicant/scan.h>
 #include <zephyr_fmac_main.h>
 }
@@ -69,30 +72,26 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(wifi_scan_result * result)
 } // namespace
 
 // These enums shall reflect the overall ordered disconnected->connected flow
-// NOTE: it's NOT a unique keyed map
-const WiFiManager::StatusMap::StatusPair WiFiManager::StatusMap::sStatusMap[] = {
-    { WPA_DISCONNECTED, WiFiManager::StationStatus::DISCONNECTED },
-    { WPA_INTERFACE_DISABLED, WiFiManager::StationStatus::DISABLED },
-    { WPA_INACTIVE, WiFiManager::StationStatus::DISABLED },
-    { WPA_SCANNING, WiFiManager::StationStatus::SCANNING },
-    { WPA_AUTHENTICATING, WiFiManager::StationStatus::CONNECTING },
-    { WPA_ASSOCIATING, WiFiManager::StationStatus::CONNECTING },
-    { WPA_ASSOCIATED, WiFiManager::StationStatus::CONNECTED },
-    { WPA_4WAY_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
-    { WPA_GROUP_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
-    { WPA_COMPLETED, WiFiManager::StationStatus::FULLY_PROVISIONED }
-};
+const Map<wpa_states, WiFiManager::StationStatus, 10>
+    WiFiManager::sStatusMap({ { WPA_DISCONNECTED, WiFiManager::StationStatus::DISCONNECTED },
+                              { WPA_INTERFACE_DISABLED, WiFiManager::StationStatus::DISABLED },
+                              { WPA_INACTIVE, WiFiManager::StationStatus::DISABLED },
+                              { WPA_SCANNING, WiFiManager::StationStatus::SCANNING },
+                              { WPA_AUTHENTICATING, WiFiManager::StationStatus::CONNECTING },
+                              { WPA_ASSOCIATING, WiFiManager::StationStatus::CONNECTING },
+                              { WPA_ASSOCIATED, WiFiManager::StationStatus::CONNECTED },
+                              { WPA_4WAY_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
+                              { WPA_GROUP_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
+                              { WPA_COMPLETED, WiFiManager::StationStatus::FULLY_PROVISIONED } });
 
-WiFiManager::StationStatus WiFiManager::StatusMap::operator[](wpa_states wpaState)
-{
-    for (const auto & it : sStatusMap)
-    {
-        if (wpaState == it.mWpaStatus)
-            return it.mStatus;
-    }
-
-    return WiFiManager::StationStatus::NONE;
-}
+// Map WiFi center frequency to the corresponding channel number
+const Map<uint16_t, uint8_t, 42> WiFiManager::sFreqChannelMap(
+    { { 4915, 183 }, { 4920, 184 }, { 4925, 185 }, { 4935, 187 }, { 4940, 188 }, { 4945, 189 }, { 4960, 192 },
+      { 4980, 196 }, { 5035, 7 },   { 5040, 8 },   { 5045, 9 },   { 5055, 11 },  { 5060, 12 },  { 5080, 16 },
+      { 5170, 34 },  { 5180, 36 },  { 5190, 38 },  { 5200, 40 },  { 5210, 42 },  { 5220, 44 },  { 5230, 46 },
+      { 5240, 48 },  { 5260, 52 },  { 5280, 56 },  { 5300, 60 },  { 5320, 64 },  { 5500, 100 }, { 5520, 104 },
+      { 5540, 108 }, { 5560, 112 }, { 5580, 116 }, { 5600, 120 }, { 5620, 124 }, { 5640, 128 }, { 5660, 132 },
+      { 5680, 136 }, { 5700, 140 }, { 5745, 149 }, { 5765, 153 }, { 5785, 157 }, { 5805, 161 }, { 5825, 165 } });
 
 CHIP_ERROR WiFiManager::Init()
 {
@@ -242,7 +241,7 @@ CHIP_ERROR WiFiManager::AddPsk(const ByteSpan & credentials)
     return CHIP_ERROR_INTERNAL;
 }
 
-WiFiManager::StationStatus WiFiManager::GetStationStatus()
+WiFiManager::StationStatus WiFiManager::GetStationStatus() const
 {
     if (wpa_s_0)
     {
@@ -255,10 +254,10 @@ WiFiManager::StationStatus WiFiManager::GetStationStatus()
     }
 }
 
-WiFiManager::StationStatus WiFiManager::StatusFromWpaStatus(wpa_states status)
+WiFiManager::StationStatus WiFiManager::StatusFromWpaStatus(const wpa_states & status)
 {
     ChipLogDetail(DeviceLayer, "WPA internal status: %d", static_cast<int>(status));
-    return WiFiManager::StatusMap::GetMap()[status];
+    return WiFiManager::sStatusMap[status];
 }
 
 CHIP_ERROR WiFiManager::EnableStation(bool enable)
@@ -328,6 +327,102 @@ void WiFiManager::PollTimerCallback()
             OnConnectionFailed();
         }
     }
+}
+
+CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
+{
+    VerifyOrReturnError(nullptr != wpa_s_0, CHIP_ERROR_INTERNAL);
+
+    static uint8_t sBssid[ETH_ALEN];
+    if (WiFiManager::StationStatus::CONNECTED <= GetStationStatus())
+    {
+        memcpy(sBssid, wpa_s_0->bssid, ETH_ALEN);
+        info.mBssId        = ByteSpan(sBssid, ETH_ALEN);
+        info.mSecurityType = GetSecurityType();
+        // TODO: this should reflect the real connection compliance
+        // i.e. the AP might support WiFi 5 only even though the station
+        // is WiFi 6 ready (so the connection is WiFi 5 effectively).
+        // For now just return what the station supports.
+        info.mWiFiVersion = EMBER_ZCL_WI_FI_VERSION_TYPE_802__11AX;
+
+        wpa_signal_info signalInfo{};
+        if (0 == wpa_drv_signal_poll(wpa_s_0, &signalInfo))
+        {
+            info.mRssi    = signalInfo.current_signal; // dBm
+            info.mChannel = FrequencyToChannel(signalInfo.frequency);
+        }
+        else
+        {
+            // this values should be nullable according to the Matter spec
+            info.mRssi    = std::numeric_limits<decltype(info.mRssi)>::min();
+            info.mChannel = std::numeric_limits<decltype(info.mChannel)>::min();
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_INTERNAL;
+}
+
+uint8_t WiFiManager::GetSecurityType() const
+{
+    VerifyOrReturnValue(nullptr != mpWpaNetwork, 0);
+
+    if ((mpWpaNetwork->key_mgmt & WPA_KEY_MGMT_NONE) || !wpa_key_mgmt_wpa_any(mpWpaNetwork->key_mgmt))
+    {
+        return 1; // NONE
+    }
+    else if (wpa_key_mgmt_wpa_psk_no_sae(mpWpaNetwork->key_mgmt))
+    {
+        return (mpWpaNetwork->pairwise_cipher & (WPA_CIPHER_TKIP | WPA_CIPHER_CCMP)) ? 4 : 3; // 4-WPA2, 3-WPA
+    }
+    else if (wpa_key_mgmt_sae(mpWpaNetwork->key_mgmt))
+    {
+        return 5; // WPA3
+    }
+    else
+    {
+        return 2; // WEP
+    }
+
+    return 0; // Unspecified
+}
+
+uint8_t WiFiManager::FrequencyToChannel(uint16_t freq)
+{
+    static constexpr uint16_t k24MinFreq{ 2401 };
+    static constexpr uint16_t k24MaxFreq{ 2484 };
+    static constexpr uint8_t k24FreqConstDiff{ 5 };
+
+    if (freq >= k24MinFreq && freq < k24MaxFreq)
+    {
+        static_cast<uint8_t>((freq - k24MinFreq) / k24FreqConstDiff + 1);
+    }
+    else if (freq == k24MaxFreq)
+    {
+        return 14;
+    }
+    else if (freq > k24MaxFreq)
+    {
+        // assume we are in 5GH band
+        return sFreqChannelMap[freq];
+    }
+    return 0;
+}
+
+CHIP_ERROR WiFiManager::GetNetworkStatistics(NetworkStatistics & stats) const
+{
+    // TODO: below will not work (result will be all zeros) until
+    // the get_stats handler is implemented in WiFi driver
+    net_stats_eth data{};
+    net_mgmt(NET_REQUEST_STATS_GET_ETHERNET, GetInterface(), &data, sizeof(data));
+
+    stats.mPacketMulticastRxCount = data.multicast.rx;
+    stats.mPacketMulticastTxCount = data.multicast.tx;
+    stats.mPacketUnicastRxCount   = data.pkts.rx - data.multicast.rx - data.broadcast.rx;
+    stats.mPacketUnicastTxCount   = data.pkts.tx - data.multicast.tx - data.broadcast.tx;
+    stats.mOverruns               = 0; // TODO: clarify if this can be queried from mgmt API (e.g. data.tx_dropped)
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -396,7 +396,7 @@ uint8_t WiFiManager::FrequencyToChannel(uint16_t freq)
 
     if (freq >= k24MinFreq && freq < k24MaxFreq)
     {
-        static_cast<uint8_t>((freq - k24MinFreq) / k24FreqConstDiff + 1);
+        return static_cast<uint8_t>((freq - k24MinFreq) / k24FreqConstDiff + 1);
     }
     else if (freq == k24MaxFreq)
     {

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -77,7 +77,7 @@ public:
     Map(Map &&)      = delete;
     Map & operator=(const Map &) = delete;
     Map & operator=(Map &&) = delete;
-    virtual ~Map()          = default;
+    ~Map()                  = default;
 
 private:
     Pair mMap[N];

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -41,9 +41,50 @@ using WpaNetwork = struct wpa_ssid;
 namespace chip {
 namespace DeviceLayer {
 
+// emulation of dictionary - might be moved to utils
+template <typename T1, typename T2, std::size_t N>
+class Map
+{
+    struct Pair
+    {
+        T1 key;
+        T2 value;
+    };
+
+public:
+    Map(const Pair (&list)[N])
+    {
+        int idx{ 0 };
+        for (const auto & pair : list)
+        {
+            mMap[idx++] = pair;
+        }
+    }
+
+    T2 operator[](const T1 & key) const
+    {
+        for (const auto & it : mMap)
+        {
+            if (key == it.key)
+                return it.value;
+        }
+
+        return T2{};
+    }
+
+    Map()            = delete;
+    Map(const Map &) = delete;
+    Map(Map &&)      = delete;
+    Map & operator=(const Map &) = delete;
+    Map & operator=(Map &&) = delete;
+    virtual ~Map()          = default;
+
+private:
+    Pair mMap[N];
+};
+
 class WiFiManager
 {
-
     using ConnectionCallback = void (*)();
 
 public:
@@ -57,26 +98,6 @@ public:
         CONNECTED,
         PROVISIONING,
         FULLY_PROVISIONED
-    };
-
-    class StatusMap
-    {
-    public:
-        static StatusMap & GetMap()
-        {
-            static StatusMap sInstance;
-            return sInstance;
-        }
-        StationStatus operator[](wpa_states wpaState);
-
-    private:
-        struct StatusPair
-        {
-            wpa_states mWpaStatus;
-            WiFiManager::StationStatus mStatus;
-        };
-
-        static const StatusPair sStatusMap[];
     };
 
     static WiFiManager & Instance()
@@ -94,28 +115,54 @@ public:
         System::Clock::Timeout mConnectionTimeoutMs{};
     };
 
+    struct WiFiInfo
+    {
+        ByteSpan mBssId{};
+        uint8_t mSecurityType{};
+        uint8_t mWiFiVersion{};
+        uint16_t mChannel{};
+        int8_t mRssi{};
+    };
+
+    struct NetworkStatistics
+    {
+        uint32_t mPacketMulticastRxCount{};
+        uint32_t mPacketMulticastTxCount{};
+        uint32_t mPacketUnicastRxCount{};
+        uint32_t mPacketUnicastTxCount{};
+        uint32_t mOverruns{};
+    };
+
     CHIP_ERROR Init();
     CHIP_ERROR Scan(const ByteSpan & ssid, ScanCallback callback);
     CHIP_ERROR Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling);
-    StationStatus GetStationStatus();
+    StationStatus GetStationStatus() const;
     CHIP_ERROR ClearStationProvisioningData();
     CHIP_ERROR DisconnectStation();
+    CHIP_ERROR GetWiFiInfo(WiFiInfo & info) const;
+    CHIP_ERROR GetNetworkStatistics(NetworkStatistics & stats) const;
 
 private:
     CHIP_ERROR AddPsk(const ByteSpan & credentials);
-    StationStatus StatusFromWpaStatus(wpa_states status);
     CHIP_ERROR EnableStation(bool enable);
     CHIP_ERROR AddNetwork(const ByteSpan & ssid, const ByteSpan & credentials);
     void PollTimerCallback();
     void WaitForConnectionAsync();
     void OnConnectionSuccess();
     void OnConnectionFailed();
+    uint8_t GetSecurityType() const;
 
     WpaNetwork * mpWpaNetwork{ nullptr };
     ConnectionCallback mConnectionSuccessClbk;
     ConnectionCallback mConnectionFailedClbk;
     System::Clock::Timeout mConnectionTimeoutMs;
     ScanCallback mScanCallback{ nullptr };
+
+    static uint8_t FrequencyToChannel(uint16_t freq);
+    static StationStatus StatusFromWpaStatus(const wpa_states & status);
+
+    static const Map<wpa_states, StationStatus, 10> sStatusMap;
+    static const Map<uint16_t, uint8_t, 42> sFreqChannelMap;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/telink/BUILD.gn
+++ b/src/platform/telink/BUILD.gn
@@ -25,6 +25,7 @@ static_library("telink") {
     "../Zephyr/ConfigurationManagerImpl.cpp",
     "../Zephyr/DiagnosticDataProviderImpl.cpp",
     "../Zephyr/DiagnosticDataProviderImpl.h",
+    "../Zephyr/DiagnosticDataProviderImplGetter.cpp",
     "../Zephyr/KeyValueStoreManagerImpl.cpp",
     "../Zephyr/Logging.cpp",
     "../Zephyr/PlatformManagerImpl.cpp",


### PR DESCRIPTION
Added support for WiFi diagnostic cluster.

Tested with chip-tool (commissioned and interact with WiFi diagnostic cluster).

Note that most of the attributes are still not supported, even though the code has been added. The reason for that is a lack of proper WiFi driver Zephyr netmgmt API.
