### PR TITLE
[scripts] created bootstrap script for ZAPZap scripts refinement

### DIFF
--- a/scripts/tools/zap/convert.py
+++ b/scripts/tools/zap/convert.py
@@ -60,13 +60,13 @@ def runArgumentsParser():
     parser = argparse.ArgumentParser(
         description='Convert .zap files to the current zap version')
     parser.add_argument('zap', help='Path to the application .zap file')
-    parser.add_argument('--no-bootstrap', default=None, action='store_true',
-                        help='Prevent automatic ZAP bootstrap. By default the bootstrap is triggered')
+    parser.add_argument('--run-bootstrap', default=None, action='store_true',
+                        help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
     args = parser.parse_args()
 
     zap_file = getFilePath(args.zap)
 
-    return zap_file, args.no_bootstrap
+    return zap_file, args.run_bootstrap
 
 
 def detectZclFile(zapFile):
@@ -104,8 +104,8 @@ def runBootstrap():
 
 def main():
     checkPythonVersion()
-    zap_file, no_bootstrap = runArgumentsParser()
-    if not no_bootstrap:
+    zap_file, run_bootstrap = runArgumentsParser()
+    if  run_bootstrap:
         runBootstrap()
     os.chdir(CHIP_ROOT_DIR)
 

--- a/scripts/tools/zap/convert.py
+++ b/scripts/tools/zap/convert.py
@@ -60,11 +60,13 @@ def runArgumentsParser():
     parser = argparse.ArgumentParser(
         description='Convert .zap files to the current zap version')
     parser.add_argument('zap', help='Path to the application .zap file')
+    parser.add_argument('--no-bootstrap', default=None, action='store_true',
+                        help='Prevent automatic ZAP bootstrap. By default the bootstrap is triggered')
     args = parser.parse_args()
 
     zap_file = getFilePath(args.zap)
 
-    return zap_file
+    return zap_file, args.no_bootstrap
 
 
 def detectZclFile(zapFile):
@@ -96,11 +98,17 @@ def runConversion(zap_file):
                           '-z', zcl_file, '-g', templates_file, '-o', zap_file, zap_file])
 
 
+def runBootstrap():
+    subprocess.check_call(getFilePath("scripts/tools/zap/zap_bootstrap.sh"), shell=True)
+
+
 def main():
     checkPythonVersion()
+    zap_file, no_bootstrap = runArgumentsParser()
+    if not no_bootstrap:
+        runBootstrap()
     os.chdir(CHIP_ROOT_DIR)
 
-    zap_file = runArgumentsParser()
     runConversion(zap_file)
 
 

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -90,8 +90,8 @@ def runArgumentsParser():
                         help='Path to the zcl templates records to use for generating artifacts (default: autodetect read from zap file)')
     parser.add_argument('-o', '--output-dir', default=None,
                         help='Output directory for the generated files (default: automatically selected)')
-    parser.add_argument('--no-bootstrap', default=None, action='store_true',
-                        help='Prevent automatic ZAP bootstrap. By default the bootstrap is triggered')
+    parser.add_argument('--run-bootstrap', default=None, action='store_true',
+                        help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
     args = parser.parse_args()
 
     # By default, this script assumes that the global CHIP template is used with
@@ -115,7 +115,7 @@ def runArgumentsParser():
     templates_file = getFilePath(args.templates)
     output_dir = getDirPath(output_dir)
 
-    return (zap_file, zcl_file, templates_file, output_dir, args.no_bootstrap)
+    return (zap_file, zcl_file, templates_file, output_dir, args.run_bootstrap)
 
 
 def extractGeneratedIdl(output_dir, zap_config_path):
@@ -217,8 +217,8 @@ def runBootstrap():
 
 def main():
     checkPythonVersion()
-    zap_file, zcl_file, templates_file, output_dir, no_bootstrap = runArgumentsParser()
-    if not no_bootstrap:
+    zap_file, zcl_file, templates_file, output_dir, run_bootstrap = runArgumentsParser()
+    if run_bootstrap:
         runBootstrap()
     # The maximum memory usage is over 4GB (#15620)
     os.environ["NODE_OPTIONS"] = "--max-old-space-size=8192"

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -90,6 +90,8 @@ def runArgumentsParser():
                         help='Path to the zcl templates records to use for generating artifacts (default: autodetect read from zap file)')
     parser.add_argument('-o', '--output-dir', default=None,
                         help='Output directory for the generated files (default: automatically selected)')
+    parser.add_argument('--no-bootstrap', default=None, action='store_true',
+                        help='Prevent automatic ZAP bootstrap. By default the bootstrap is triggered')
     args = parser.parse_args()
 
     # By default, this script assumes that the global CHIP template is used with
@@ -113,7 +115,7 @@ def runArgumentsParser():
     templates_file = getFilePath(args.templates)
     output_dir = getDirPath(output_dir)
 
-    return (zap_file, zcl_file, templates_file, output_dir)
+    return (zap_file, zcl_file, templates_file, output_dir, args.no_bootstrap)
 
 
 def extractGeneratedIdl(output_dir, zap_config_path):
@@ -209,12 +211,17 @@ def runJavaPrettifier(templates_file, output_dir):
         print('google-java-format error:', err)
 
 
+def runBootstrap():
+    subprocess.check_call(getFilePath("scripts/tools/zap/zap_bootstrap.sh"), shell=True)
+
+
 def main():
     checkPythonVersion()
-
-    # The maximum meory usage is over 4GB (#15620)
+    zap_file, zcl_file, templates_file, output_dir, no_bootstrap = runArgumentsParser()
+    if not no_bootstrap:
+        runBootstrap()
+    # The maximum memory usage is over 4GB (#15620)
     os.environ["NODE_OPTIONS"] = "--max-old-space-size=8192"
-    zap_file, zcl_file, templates_file, output_dir = runArgumentsParser()
     runGeneration(zap_file, zcl_file, templates_file, output_dir)
 
     prettifiers = [

--- a/scripts/tools/zap/run_zaptool.sh
+++ b/scripts/tools/zap/run_zaptool.sh
@@ -33,17 +33,9 @@ CHIP_ROOT="${SCRIPT_PATH%/scripts/tools/zap/run_zaptool.sh}"
 
 (
 
-    cd "$CHIP_ROOT" &&
-        git submodule update --init third_party/zap/repo
+    "$CHIP_ROOT"/scripts/tools/zap/zap_bootstrap.sh
 
-    cd "third_party/zap/repo"
-    if ! npm list installed-check &>/dev/null; then
-        npm install installed-check
-    fi
-
-    if ! ./node_modules/.bin/installed-check -c &>/dev/null; then
-        npm install
-    fi
+    cd "$CHIP_ROOT/third_party/zap/repo"
 
     echo "ARGS: ${ZAP_ARGS[@]}"
 

--- a/scripts/tools/zap/zap_bootstrap.sh
+++ b/scripts/tools/zap/zap_bootstrap.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function _get_fullpath() {
+    cd "$(dirname "$1")" && echo "$PWD/$(basename "$1")"
+}
+
+echo "ZAP bootstrap started..."
+
+set -e
+
+SCRIPT_PATH="$(_get_fullpath "$0")"
+CHIP_ROOT="${SCRIPT_PATH%/scripts/tools/zap/zap_bootstrap.sh}"
+
+(
+    cd "$CHIP_ROOT" &&
+        git submodule update --init third_party/zap/repo
+
+    cd "third_party/zap/repo"
+    if ! npm list installed-check &>/dev/null; then
+        npm install installed-check
+    fi
+
+    if ! ./node_modules/.bin/installed-check -c &>/dev/null; then
+        npm install
+    fi
+)
+
+echo "ZAP bootstrap done!"

--- a/scripts/tools/zap/zap_bootstrap.sh
+++ b/scripts/tools/zap/zap_bootstrap.sh
@@ -20,7 +20,15 @@ function _get_fullpath() {
     cd "$(dirname "$1")" && echo "$PWD/$(basename "$1")"
 }
 
-echo "ZAP bootstrap started..."
+function _usage {
+    cat << EOF
+Invalid arguments passed.
+Usage:
+    zap_bootstrap.sh -> install and update required packages
+    zap_bootstrap.sh -c -> run a clean bootstrap, install packages from scratch
+EOF
+   exit 1
+}
 
 set -e
 
@@ -32,12 +40,24 @@ CHIP_ROOT="${SCRIPT_PATH%/scripts/tools/zap/zap_bootstrap.sh}"
         git submodule update --init third_party/zap/repo
 
     cd "third_party/zap/repo"
-    if ! npm list installed-check &>/dev/null; then
-        npm install installed-check
-    fi
 
-    if ! ./node_modules/.bin/installed-check -c &>/dev/null; then
-        npm install
+    if [ $# -eq 0 ]; then
+        echo "Running ZAP bootstrap"
+        if ! npm list installed-check &>/dev/null; then
+            npm install installed-check
+        fi
+
+        if ! ./node_modules/.bin/installed-check -c &>/dev/null; then
+            npm install
+        fi
+    elif [ $# -eq 1 ] && [ "$1" = "-c" ]; then
+        echo "Running clean ZAP bootstrap"
+        npm ci
+        npm run version-stamp
+        npm rebuild canvas --update-binary
+        npm run build-spa
+    else
+        _usage
     fi
 )
 

--- a/scripts/tools/zap_convert_all.py
+++ b/scripts/tools/zap_convert_all.py
@@ -53,13 +53,18 @@ def getTargets():
     return targets
 
 
+def runBootstrap():
+    subprocess.check_call(os.path.join(CHIP_ROOT_DIR, "scripts/tools/zap/zap_bootstrap.sh"), shell=True)
+
+
 def main():
     checkPythonVersion()
+    runBootstrap()
     os.chdir(CHIP_ROOT_DIR)
 
     targets = getTargets()
     for target in targets:
-        subprocess.check_call(['./scripts/tools/zap/convert.py'] + target)
+        subprocess.check_call(['./scripts/tools/zap/convert.py'] + ['--no-bootstrap'] + target)
 
 
 if __name__ == '__main__':

--- a/scripts/tools/zap_convert_all.py
+++ b/scripts/tools/zap_convert_all.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 import sys
 import subprocess
+import argparse
 
 CHIP_ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '../..'))
@@ -53,18 +54,28 @@ def getTargets():
     return targets
 
 
+def runArgumentsParser():
+    parser = argparse.ArgumentParser(
+        description='Convert all .zap files to the current zap version')
+    parser.add_argument('--run-bootstrap', default=None, action='store_true',
+                        help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
+    return parser.parse_args()
+
+
 def runBootstrap():
     subprocess.check_call(os.path.join(CHIP_ROOT_DIR, "scripts/tools/zap/zap_bootstrap.sh"), shell=True)
 
 
 def main():
+    args = runArgumentsParser()
     checkPythonVersion()
-    runBootstrap()
+    if args.run_bootstrap:
+        runBootstrap()
     os.chdir(CHIP_ROOT_DIR)
 
     targets = getTargets()
     for target in targets:
-        subprocess.check_call(['./scripts/tools/zap/convert.py'] + ['--no-bootstrap'] + target)
+        subprocess.check_call(['./scripts/tools/zap/convert.py'] + target)
 
 
 if __name__ == '__main__':

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -46,7 +46,7 @@ class ZAPGenerateTarget:
     def build_cmd(self):
         """Builds the command line we would run to generate this target.
         """
-        cmd = [self.script, self.zap_config]
+        cmd = [self.script, '--no-bootstrap', self.zap_config]
 
         if self.template:
             cmd.append('-t')
@@ -93,7 +93,7 @@ def setupArgumentsParser():
     parser.add_argument('--tests', default='all', choices=['all', 'chip-tool', 'darwin-framework-tool', 'app1', 'app2'],
                         help='When generating tests only target, Choose which tests to generate (default: all)')
     parser.add_argument('--dry-run', default=False, action='store_true',
-                        help="Don't do any generationl just log what targets would be generated (default: False)")
+                        help="Don't do any generation, just log what targets would be generated (default: False)")
     return parser.parse_args()
 
 
@@ -224,6 +224,10 @@ def getTargets(type, test_target):
     return targets
 
 
+def runBootstrap():
+    subprocess.check_call(os.path.join(CHIP_ROOT_DIR, "scripts/tools/zap/zap_bootstrap.sh"), shell=True)
+
+
 def main():
     logging.basicConfig(
         level=logging.INFO,
@@ -236,6 +240,7 @@ def main():
     targets = getTargets(args.type, args.tests)
 
     if (not args.dry_run):
+        runBootstrap()
         for target in targets:
             target.generate()
 

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -46,7 +46,7 @@ class ZAPGenerateTarget:
     def build_cmd(self):
         """Builds the command line we would run to generate this target.
         """
-        cmd = [self.script, '--no-bootstrap', self.zap_config]
+        cmd = [self.script, self.zap_config]
 
         if self.template:
             cmd.append('-t')
@@ -94,6 +94,8 @@ def setupArgumentsParser():
                         help='When generating tests only target, Choose which tests to generate (default: all)')
     parser.add_argument('--dry-run', default=False, action='store_true',
                         help="Don't do any generation, just log what targets would be generated (default: False)")
+    parser.add_argument('--run-bootstrap', default=None, action='store_true',
+                        help='Automatically run ZAP bootstrap. By default the bootstrap is not triggered')
     return parser.parse_args()
 
 
@@ -240,7 +242,8 @@ def main():
     targets = getTargets(args.type, args.tests)
 
     if (not args.dry_run):
-        runBootstrap()
+        if (args.run_bootstrap):
+            runBootstrap()
         for target in targets:
             target.generate()
 


### PR DESCRIPTION
#### Issue Being Resolved
- Fixes #22687

#### Change overview
Extracted the ZAP tool bootstrap code from the `run_zaptool.sh` and populated it in the standalone scripts.

#### Testing
Tested on a pure Ubuntu 20.04 by cloning chip repo and running:
- `generate.py`
- `convert.py`
- `zap_regen_all.py`
- `zap_convert_all.py`

without running zaptool before. As a result all required nodejs packets are installed and the scripts run properly.


